### PR TITLE
Update txt2img.py

### DIFF
--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -330,7 +330,7 @@ def main():
                     # to image
                     grid = 255. * rearrange(grid, 'c h w -> h w c').cpu().numpy()
                     img = Image.fromarray(grid.astype(np.uint8))
-                    img = put_watermark(img, wm_encoder)
+                    #img = put_watermark(img, wm_encoder)
                     img.save(os.path.join(outpath, f'grid-{grid_count:04}.png'))
                     grid_count += 1
 


### PR DESCRIPTION
it seems you forgot to disable watermarking in case of grid output.
So I've fixed just that.